### PR TITLE
fix: findInitMonthNumber

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -449,7 +449,7 @@ export class CalendarPage{
 
     if(!isAfter) return 0;
 
-    return  defaultDate.subtract(startDate).month();
+    return  defaultDate.diff(startDate, 'month');
   }
 
 }


### PR DESCRIPTION
修复因计算差值的方法不对，导致滚动到默认日期的不准确