### PR TITLE
change the onWillDismiss() to onDidDismiss(). 

### DIFF
--- a/src/calendar.controller.ts
+++ b/src/calendar.controller.ts
@@ -29,7 +29,7 @@ export class CalendarController {
 
         return new Promise( (resolve, reject) => {
 
-            calendarModal.onWillDismiss((data:any) => {
+            calendarModal.onDidDismiss((data:any) => {
                 let result: {
                     date?: any;
                     from?: any;


### PR DESCRIPTION
More robust in terms when the calendar component is opened from within nested modals or popups. the onWillDismiss() fails when the calendar is opened from a modal that is itself in a modal, for more details see: 

https://l.facebook.com/l.php?u=https%3A%2F%2Fgithub.com%2Fionic-team%2Fionic%2Fissues%2F10281&h=ATMenpgA8j1lwNgrE7NzucjAnKEm0FvcHWcwOhPcq-4xPb4FMGZ_--eYNB6fng__bGW_fakp9EYKJv_48TWx9ui3CMADNwgEnl2A5y0kF-iZbic6ufkWvIFnAJlmpvZjZcrb7nxtqA