### PR TITLE
fix weekdays title for component mode

### DIFF
--- a/src/components/calendar.component.ts
+++ b/src/components/calendar.component.ts
@@ -55,6 +55,7 @@ export const ION_CAL_VALUE_ACCESSOR: any = {
     
     <ng-template [ngIf]="_view === 'days'" [ngIfElse]="monthPicker">
       <ion-calendar-week color="transparent"
+                         [weekArray]="_d.weekdays"
                          [weekStart]="_d.weekStart">
       </ion-calendar-week>
 


### PR DESCRIPTION
As described on the Readme file, the component mode should allow to change the weekdays titles. Unfortunately, currently it does not work because the attribute is missing on the template.

the field weekdays can be passed and display correctly now.

```
this.calendarOptions = {
            weekdays: ['D', 'L', 'M', 'X', 'J', 'V', 'S'],
            weekStart: 1
};

<ion-calendar [(ngModel)]="model.date"
                      [options]="calendarOptions">
</ion-calendar>

```