### PR TITLE
Don't use Angular 5 packages for an Angular 4 based project

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "devDependencies": {
     "@angular/common": "4.4.6",
-    "@angular/compiler": "^5.0.0",
-    "@angular/compiler-cli": "^5.0.0",
+    "@angular/compiler": "4.4.6",
+    "@angular/compiler-cli": "4.4.6",
     "@angular/core": "4.4.6",
     "@angular/forms": "4.4.6",
     "@angular/http": "4.4.6",


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

Resolves the problem of the compiler being for Angular 5, which is incompatible with Angular 4 based projects when attempting to run the Ionic project with the --prod flag.

<!-- Please check the one that applies to this PR using "x". -->
```
[*] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Demos changes
[ ] Other... Please describe:
```

## What is the current behavior?

At the moment on an Angular 4 based project you cannot run Ionic with the --prod flag because of the dependency inclusion of Angular 5 packages (angular/compiler & angular/compiler-cli), which is incompatible because of a version mismatch (3 to 4).

Issue Number: #161 

## What is the new behavior?

This reverts the package dependency of angular/compiler and angular/compiler-cli to be 4.4.6 so that it is compatible with the rest of the packages in package.json (Angular 4.4.6)

## Does this PR introduce a breaking change?
```
[*] Yes
[ ] No
```
This will introduce a problem for Angular 5 based packages, but my suggestion below would fix that.

## Other information

I would suggest splitting this off into an Angular 4 branch, and having current master be updated for Angular 5, rather than having mixed 4/5 dependencies.