### PR TITLE
fix: add support for ionicons 5.0.0

### DIFF
--- a/dev/src/ion2-calendar/components/calendar.component.ts
+++ b/dev/src/ion2-calendar/components/calendar.component.ts
@@ -35,7 +35,7 @@ export const ION_CAL_VALUE_ACCESSOR: Provider = {
                     (click)="switchView()">
           {{ _monthFormat(monthOpt.original.time) }}
           <ion-icon class="arrow-dropdown"
-                    [name]="_view === 'days' ? 'md-arrow-dropdown' : 'md-arrow-dropup'"></ion-icon>
+                    [name]="_view === 'days' ? 'caret-down' : 'caret-up'"></ion-icon>
         </ion-button>
       </ng-template>
       <ng-template #title>
@@ -46,10 +46,10 @@ export const ION_CAL_VALUE_ACCESSOR: Provider = {
       </ng-template>
       <ng-template [ngIf]="_showToggleButtons">
         <ion-button type="button" fill="clear" class="back" [disabled]="!canBack()" (click)="prev()">
-          <ion-icon slot="icon-only" size="small" name="ios-arrow-back"></ion-icon>
+          <ion-icon slot="icon-only" size="small" name="chevron-back"></ion-icon>
         </ion-button>
         <ion-button type="button" fill="clear" class="forward" [disabled]="!canNext()" (click)="next()">
-          <ion-icon slot="icon-only" size="small" name="ios-arrow-forward"></ion-icon>
+          <ion-icon slot="icon-only" size="small" name="chevron-forward"></ion-icon>
         </ion-button>
       </ng-template>
     </div>

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gulp-clean": "^0.4.0",
     "gulp-ext-replace": "^0.3.0",
     "gulp-sass": "^4.0.1",
-    "ionicons": "4.5.1",
+    "ionicons": "5.0.0",
     "moment": "^2.23.0",
     "ng-packagr": "^2.0.0",
     "npm-run-all": "^4.1.2",

--- a/src/components/calendar.component.ts
+++ b/src/components/calendar.component.ts
@@ -34,7 +34,7 @@ export const ION_CAL_VALUE_ACCESSOR: Provider = {
                 (click)="switchView()">
           {{ _monthFormat(monthOpt.original.time) }}
           <ion-icon class="arrow-dropdown"
-                    [name]="_view === 'days' ? 'md-arrow-dropdown' : 'md-arrow-dropup'"></ion-icon>
+                    [name]="_view === 'days' ? 'caret-down' : 'caret-up'"></ion-icon>
         </ion-button>
       </ng-template>
       <ng-template #title>
@@ -44,10 +44,10 @@ export const ION_CAL_VALUE_ACCESSOR: Provider = {
       </ng-template>
       <ng-template [ngIf]="_showToggleButtons">
         <ion-button type="button" fill="clear" class="back" [disabled]="!canBack()" (click)="prev()">
-          <ion-icon slot="icon-only" size="small" name="ios-arrow-back"></ion-icon>
+          <ion-icon slot="icon-only" size="small" name="chevron-back"></ion-icon>
         </ion-button>
         <ion-button type="button" fill="clear" class="forward" [disabled]="!canNext()" (click)="next()">
-          <ion-icon slot="icon-only" size="small" name="ios-arrow-forward"></ion-icon>
+          <ion-icon slot="icon-only" size="small" name="chevron-forward"></ion-icon>
         </ion-button>
       </ng-template>
     </div>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
Support for ionicons 5.0.0
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Demos changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The names of some ionicons changed as of 5.0.0, breaking arrows in the calendar.
Issue Number: #283


## What is the new behavior?
The deprecated names have been replaced with their new variants, fixing the broken icons.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
I don't believe the arrows will show correctly for anybody still using ionicons 4.x.x.
## Other information
I tried going through your contributing guidelines before submitting this, but I didn't understand the whole dev folder concept and kept getting compiler errors... In frustration, I simply made the bare minimum changes needed, which is what you'll see in this PR.